### PR TITLE
Fix 'Highlights' parameter to vim.treesitter.get_query

### DIFF
--- a/denops/@ddc-sources/treesitter.ts
+++ b/denops/@ddc-sources/treesitter.ts
@@ -1,12 +1,12 @@
-import { Denops, fn } from "https://deno.land/x/ddc_vim@v0.13.0/deps.ts#^";
+import { Denops, fn } from "https://deno.land/x/ddc_vim@v0.17.0/deps.ts#^";
 import {
   BaseSource,
   Candidate,
-} from "https://deno.land/x/ddc_vim@v0.13.0/types.ts#^";
+} from "https://deno.land/x/ddc_vim@v0.17.0/types.ts#^";
 import {
   GatherCandidatesArguments,
   OnInitArguments,
-} from "https://deno.land/x/ddc_vim@v0.13.0/base/source.ts#^";
+} from "https://deno.land/x/ddc_vim@v0.17.0/base/source.ts#^";
 
 interface NodeInfo {
   word: string;

--- a/lua/ddc-treesitter.lua
+++ b/lua/ddc-treesitter.lua
@@ -4,7 +4,7 @@ M.gather_candidates = function()
   local candidates = {}
   local ok, parser = pcall(vim.treesitter.get_parser)
   if not ok then return candidates end
-  local query = vim.treesitter.get_query(parser:lang(), 'Highlights')
+  local query = vim.treesitter.get_query(parser:lang(), 'highlights')
   if not query then return candidates end
   for _, tree in pairs(parser:parse()) do
     for i, node in query:iter_captures(tree:root(), 0) do


### PR DESCRIPTION
- Update to 0.17.0
- Bug occurring when 'Highlights' is used instead of 'highlights' (I am using nvim-treesitter `83efae51bfe92163e7cb0d215d9e9f746830ab6f` (latest) and **nvim** `v0.6.0-dev+550-g29cec32f4`).
